### PR TITLE
Instead of using jetty directly, pass the handler to lein, lein will

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,11 @@
                  [ring/ring-jetty-adapter "1.3.2"]
                  [compojure "1.3.1"]
                  [org.clojure/java.jdbc "0.3.2"]
-                 [postgresql "9.1-901.jdbc4"]]
-  :main ^:skip-aot bookclub.core
-  :plugins [[lein-ring "0.7.1"]]
+                 [postgresql "9.1-901.jdbc4"]
+                 [ring/ring-defaults "0.1.4"]]
+  :plugins [[lein-ring "0.9.1"]]
+  :ring {:handler bookclub.core/app}
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}})
+  :profiles {:uberjar {:aot :all}
+             :dev {:dependencies [[javax.servlet/servlet-api "2.5"]
+                                  [ring-mock "0.1.5"]]}})

--- a/src/bookclub/core.clj
+++ b/src/bookclub/core.clj
@@ -1,6 +1,8 @@
-(ns web.core
+(ns bookclub.core
   (:require [compojure.core :refer [defroutes GET]]
-    [ring.adapter.jetty :as ring]))
+            [compojure.route :as route]
+            [ring.middleware.defaults :refer [wrap-defaults site-defaults]]
+            [ring.adapter.jetty :as ring]))
 
 ; (defn -main
 ;   "I don't do a whole lot ... yet."
@@ -13,7 +15,12 @@
 ;     :body "Hello World"})
 
 (defroutes routes
-  (GET "/" [] "<h2>Hello World</h2>"))
+  (GET "/" [] "<h2>Hello World</h2>")
+  (route/resources "/")
+  (route/not-found "Not Found"))
 
-(defn -main []
-  (ring/run-jetty #'routes {:port 3000 :join? false}))
+; Might want to use `api-defaults` instead of `site-defaults`, depending on
+; whether it's going to be a site or an api
+; https://github.com/ring-clojure/ring-defaults
+(def app
+  (wrap-defaults routes site-defaults))


### PR DESCRIPTION
then start the server for us. Use middleware provided by ring-defaults,
and add a couple of catch-all routes.
